### PR TITLE
Support using an abstract base model.

### DIFF
--- a/src/django_shared_property/decorator.py
+++ b/src/django_shared_property/decorator.py
@@ -40,6 +40,12 @@ class SharedPropertyField(AutoField):
             return self.expression.output_field
         return self.expression.resolve_expression(Query(self.model)).output_field
 
+    def contribute_to_class(self, cls, name, **kwargs):
+        if self not in cls._meta.fields:
+            cls._meta.add_field(self, private=True)
+            if not getattr(cls, self.attname, None):
+                setattr(cls, self.attname, self)
+
 
 class shared_property(object):
     def __init__(self, func):

--- a/tests/models.py
+++ b/tests/models.py
@@ -145,3 +145,18 @@ class Person(models.Model):
 
 class Address(models.Model):
     person = models.OneToOneField(Person, related_name="address", primary_key=True, on_delete=models.CASCADE)
+
+
+class Abstract(models.Model):
+    foo = models.TextField()
+
+    @shared_property
+    def bar(self):
+        return models.F('foo')
+
+    class Meta:
+        abstract = True
+
+
+class Concrete(Abstract):
+    baz = models.TextField()


### PR DESCRIPTION
Without this change, django will trigger the error messages around multiple AutoFields being applied.